### PR TITLE
🔧fix: vercel 새로고침 및 경로 이동시 404 에러 해결

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+	"rewrites": [{ "source": "/((?!).*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
# 구현 기능
- [x] vercel 404 에러 해결

# 구현 상태
- 프론트 배포 주소에서 uri를 입력하여 접속하면 404 에러가 발생하는 문제가 발생했습니다. 모든 요청에 대해서 index.html로 리디렉션하도록 vercel.json 파일을 생성했습니다.
